### PR TITLE
Terminated

### DIFF
--- a/examples/terminated.md
+++ b/examples/terminated.md
@@ -50,9 +50,13 @@ The virtual classroom session has terminated. The session ends when the last par
 }
 ```
 
-## Rules
+## Properties
 
 - `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `verb.id`: INCLUDED, must be `http://adlnet.gov/expapi/verbs/terminated`.
+
+## Rules
+
 - `result.duration`: INCLUDED, ISO 8601 duration, time between the `initialized` and `terminated` statements.
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).

--- a/examples/terminated.md
+++ b/examples/terminated.md
@@ -9,7 +9,6 @@ The virtual classroom session has terminated. The session ends when the last par
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
@@ -19,42 +18,45 @@ The virtual classroom session has terminated. The session ends when the last par
       "id": "http://adlnet.gov/expapi/verbs/terminated"
    },
    "object": {
-      "objectType": "Activity",
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
          "type": "http://id.tincanapi.com/activitytype/webinar",
          "name": {
-            "en": "Demonstration webinar"
+            "en": "xAPI 101"
          }
       }
    },
    "result": {
-      "extensions": {
-         "http://id.tincanapi.com/extension/duration": 27.47
-      }
+      "duration": "PT16.36S"
    },
    "context": {
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/ba297687-b1aa-455757-9efd-a782c8fdb90a",
-               "definition": {
-                  "type": "https://w3id.org/xapi/acrossx/activities/webpage",
-                  "extensions": {
-                     "https://w3id.org/xapi/acrossx/extensions/type": "course"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/terminated",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "http://id.tincanapi.com/extension/planned-duration": "PT2",
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```
+
+## Rules
+
+- `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `result.duration`: INCLUDED, ISO 8601 duration, time between the `initialized` and `terminated` statements.
+- `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
+- `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
+- `context.extensions.http://id.tincanapi.com/extension/planned-duration`: RECOMMENDED, ISO 8601 duration.
+- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `timestamp`: INCLUDED
+


### PR DESCRIPTION
Very similar to the proposed `initialized` statement (https://github.com/gaia-x-dases/xapi-virtual-classroom/pull/9).

I changed the `result` section in order to adopt the standard `result.duration` property with an ISO 8601 duration format.

I kept the `planned-duration` context extension in this statement because from a data analytics perspective it may be interesting to compare the `planned-duration` and the `result.duration`. So it will be easier if we have them in the same statement.