### PR TITLE
Joined / Left

### DIFF
--- a/examples/joined.md
+++ b/examples/joined.md
@@ -48,9 +48,13 @@ A participant has joined the virtual classroom session.
 }
 ```
 
-## Rules
+## Properties
 
 - `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `verb.id`: INCLUDED, must be `http://activitystrea.ms/join`
+
+## Rules
+
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extension/camera-activated`: RECOMMENDED (level 3).

--- a/examples/joined.md
+++ b/examples/joined.md
@@ -9,7 +9,6 @@ A participant has joined the virtual classroom session.
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
@@ -19,42 +18,44 @@ A participant has joined the virtual classroom session.
       "id": "http://activitystrea.ms/join"
    },
    "object": {
-      "objectType": "Activity",
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
          "type": "http://id.tincanapi.com/activitytype/webinar",
          "name": {
-            "en": "Demonstration webinar"
+            "en": "xAPI 101"
          }
       }
    },
    "context": {
-      "extensions": {
-         "https://w3id.org/xapi/video/extensions/user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.43 Safari/537.31",
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/camera-activated": true,
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/micro-activated": false
-      },
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/ba297687-b1aa-455757-9efd-a782c8fdb90a",
-               "definition": {
-                  "type": "https://w3id.org/xapi/acrossx/activities/webpage",
-                  "extensions": {
-                     "https://w3id.org/xapi/acrossx/extensions/type": "course"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/joined",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963",
+         "https://w3id.org/xapi/virtual-classroom/extension/camera-activated": true,
+         "https://w3id.org/xapi/virtual-classroom/extension/micro-activated": false
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```
+
+## Rules
+
+- `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
+- `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
+- `context.extensions.https://w3id.org/xapi/virtual-classroom/extension/camera-activated`: RECOMMENDED (level 3).
+- `context.extensions.https://w3id.org/xapi/virtual-classroom/extension/micro-activated`: RECOMMENDED (level 3).
+- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `timestamp`: INCLUDED.
+- This statement MUST also be sent for the person who started the virtual classroom (statement `initialized`). 
+

--- a/examples/joined.md
+++ b/examples/joined.md
@@ -51,7 +51,7 @@ A participant has joined the virtual classroom session.
 ## Properties
 
 - `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
-- `verb.id`: INCLUDED, must be `http://activitystrea.ms/join`
+- `verb.id`: INCLUDED, must be `http://activitystrea.ms/join`.
 
 ## Rules
 

--- a/examples/left.md
+++ b/examples/left.md
@@ -46,9 +46,13 @@ A participant has left the virtual classroom session.
 }
 ```
 
-## Rules
+## Properties
 
 - `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `verb.id`: INCLUDED, must be `http://activitystrea.ms/leave`.
+
+## Rules
+
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.

--- a/examples/left.md
+++ b/examples/left.md
@@ -9,7 +9,6 @@ A participant has left the virtual classroom session.
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
@@ -19,37 +18,40 @@ A participant has left the virtual classroom session.
       "id": "http://activitystrea.ms/leave"
    },
    "object": {
-      "objectType": "Activity",
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
          "type": "http://id.tincanapi.com/activitytype/webinar",
          "name": {
-            "en": "Demonstration webinar"
+            "en": "xAPI 101"
          }
       }
    },
    "context": {
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/ba297687-b1aa-455757-9efd-a782c8fdb90a",
-               "definition": {
-                  "type": "https://w3id.org/xapi/acrossx/activities/webpage",
-                  "extensions": {
-                     "https://w3id.org/xapi/acrossx/extensions/type": "course"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/left",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```
+
+## Rules
+
+- `object.definition.type`: INCLUDED, must be `http://id.tincanapi.com/activitytype/webinar`.
+- `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
+- `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
+- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `timestamp`: INCLUDED.
+- This statement MUST also be sent for the person who stopped the virtual classroom (statement `terminated`). 
+


### PR DESCRIPTION
Very similar to the proposed `initialized` statement (https://github.com/gaia-x-dases/xapi-virtual-classroom/pull/9).

Regarding the `joined` statement and its `camera-activated` and `micro-activated` extensions:
- IRI prefixed by `https://w3id.org/xapi/virtual-classroom` (if possible)
- Rule: RECOMMENDED (conformance level 3 if we agree with https://github.com/gaia-x-dases/xapi-virtual-classroom/pull/12)

Additional rule to add to the human-readable specification: the `joined` and `left` statements must be sent also for the person who started and stopped the virtual classroom (`initialized` and `terminated`). 

