### PR TITLE
Updated optional statements examples

### DIFF
--- a/statements/optional/created-poll.md
+++ b/statements/optional/created-poll.md
@@ -2,59 +2,73 @@
 
 ## Description
 
-A poll has been created in the virtual classroom in order to collect participants opinions about a given question.
+A poll has been started in the virtual classroom in order to collect participants opinions about a given question.
 
 ## Example
 
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://activitystrea.ms/create"
+      "id": "http://adlnet.gov/expapi/verbs/asked"
    },
    "object": {
-      "objectType": "Activity",
-      "id": "http://gaiax.org/xapi/activities/a0f9f133-1ef2-4c2d-8677-bc33085a2346",
-      "definition": {
-         "type": "http://activitystrea.ms/question",
-         "name": {
-            "en": "When was Europe created?"
-         }
-      }
-   },
-   "result": {
-      "extensions": {
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/response-type": "textbox"
-      }
+      "id": "http://gaiax.org/xapi/activities/f3757ec4-e427-4e3e-a934-fbccdd440a32",
+      "description": {
+            "en-US": "Which e-Learning standard do you know?"
+        },
+        "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+        "interactionType": "choice",
+        "choices": [
+            {
+                "id": "scorm", 
+                "description": {
+                    "en-US": "SCORM"
+                }
+            },
+            {
+                "id": "xapi", 
+                "description": {
+                    "en-US": "xAPI"
+                }
+            },
+            {
+                "id": "lti", 
+                "description": {
+                    "en-US": "LTI"
+                }
+            }
+        ]
    },
    "context": {
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
          "parent": [
             {
                "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
                "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
+                  "type": "http://id.tincanapi.com/activitytype/webinar"
                }
             }
          ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/created-poll",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/lowered-hand.md
+++ b/statements/optional/lowered-hand.md
@@ -9,44 +9,39 @@ A user has lowered the hand in the discussion.
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/lowered-hand"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/lowered-hand"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "edward",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/lowered-hand",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/muted.md
+++ b/statements/optional/muted.md
@@ -9,47 +9,39 @@ A participant has been muted. The action has been done by the participant itself
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/muted"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/muted"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "edward",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
-      "extensions": {
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/camera-activated": true
-      },
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/muted",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/started-camera.md
+++ b/statements/optional/started-camera.md
@@ -9,47 +9,39 @@ A user has started the camera. The action has been done by the participant itsel
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/started-camera"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/started-camera"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "edward",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
-      "extensions": {
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/micro-activated": false
-      },
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/started-camera",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/stopped-camera.md
+++ b/statements/optional/stopped-camera.md
@@ -9,47 +9,39 @@ A user has stopped the camera. The action has been done by the participant itsel
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/stopped-camera"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/stopped-camera"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "edward",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
-      "extensions": {
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/micro-activated": false
-      },
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/stopped-camera",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/unmuted.md
+++ b/statements/optional/unmuted.md
@@ -9,48 +9,39 @@ A user has been unmuted. The action has been done by the participant itself or b
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/unmuted"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/unmuted"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "john",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
-      "extensions": {
-         "https://w3id.org/xapi/video/extensions/volume": 1,
-         "http://schema.dases.eu/xapi/profile/virtual-classroom/extension/camera-activated": true
-      },
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/unmuted",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```

--- a/statements/optional/unshared-screen.md
+++ b/statements/optional/unshared-screen.md
@@ -9,44 +9,39 @@ A user has unshared the screen.
 ```json
 {
    "actor": {
-      "objectType": "Agent",
       "account": {
          "name": "john",
          "homePage": "http://gaiax-virtualclassroom.org"
       }
    },
    "verb": {
-      "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/verb/unshared-screen"
+      "id": "https://w3id.org/xapi/virtual-classroom/verbs/unshared-screen"
    },
    "object": {
-      "objectType": "Agent",
-      "account": {
-         "name": "john",
-         "homePage": "http://gaiax-virtualclassroom.org"
+      "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
+      "definition": {
+         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "name": {
+            "en": "xAPI 101"
+         }
       }
    },
    "context": {
+      "registration": "4eb0e063-669b-479a-86b3-f9be9ac88a1d",
       "contextActivities": {
-         "parent": [
-            {
-               "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
-               "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar",
-                  "name": {
-                     "en": "Demonstration webinar"
-                  }
-               }
-            }
-         ],
          "category": [
             {
-               "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/unshared-screen",
+               "id": "https://w3id.org/xapi/virtual-classroom",
                "definition": {
                   "type": "http://adlnet.gov/expapi/activities/profile"
                }
             }
          ]
+      },
+      "extensions": {
+         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "c7b6f0a9-482c-4c03-acc1-548289126963"
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```


### PR DESCRIPTION
Most statements have the same structure (except `created poll`):
- The object is the virtual classroom, because we need an object and that's the only thing we can put in it consistently
- The context has always the same properties
- Only the verb really differs

I removed extensions such as `camera-activated` and `micro-activated` as they are redundant with the statements (`muted`, `unmuted`, `started-camera`, `stopped-camera`).

I also removed the `volume` extension because I don't understand the value of this information. I mean, does it help to understand what happened during the virtual classroom session?

Regarding the `created poll`:
- I replaced the `created` verb by the `asked` verb. We don't care when the instructor designed or created the poll. We just need to know when he asked the question.
- The `object` is consistent with the `object` of the `answered poll` statement (CMI interaction).
- The `result` has been removed. It is needed when the learner answers, not when the instructor ask the question.