### PR TITLE
Change webinar activity type

### DIFF
--- a/profile/base.jsonld
+++ b/profile/base.jsonld
@@ -159,7 +159,7 @@
                 "en": "The virtual classroom session has started.\nThe session is initialized when the first participant or an administrator session has entered the virtual classroom."
             },
             "verb": "http://adlnet.gov/expapi/verbs/initialized",
-            "objectActivityType": "http://id.tincanapi.com/activitytype/webinar",
+            "objectActivityType": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
             "rules": [
                 {
                     "location": "$.context.extensions['http://id.tincanapi.com/extension/planned-duration']",
@@ -182,7 +182,7 @@
                 "en": "The virtual classroom session has terminated.\nThe session ends when the last participant has left the classroom or when an administrator has ended the session."
             },
             "verb": "http://adlnet.gov/expapi/verbs/terminated",
-            "objectActivityType": "http://id.tincanapi.com/activitytype/webinar",
+            "objectActivityType": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
             "rules": [
                 {
                     "location": "$.result.duration",
@@ -201,7 +201,7 @@
                 "en": "A participant has joined the virtual classroom session."
             },
             "verb": "http://activitystrea.ms/join",
-            "objectActivityType": "http://id.tincanapi.com/activitytype/webinar",
+            "objectActivityType": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
             "rules": [
                 {
                     "location": "$.context.extensions['https://w3id.org/xapi/video/extensions/user-agent']",
@@ -228,7 +228,7 @@
                 "en": "A participant has left the virtual classroom session."
             },
             "verb": "http://activitystrea.ms/leave",
-            "objectActivityType": "http://id.tincanapi.com/activitytype/webinar"
+            "objectActivityType": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom"
         },
         {
             "id": "http://schema.dases.eu/xapi/profile/virtual-classroom/templates/muted",

--- a/statements/mandatory/initialized.md
+++ b/statements/mandatory/initialized.md
@@ -20,7 +20,7 @@ The virtual classroom session has started. The session is initialized when the f
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ The virtual classroom session has started. The session is initialized when the f
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/initialized` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/mandatory/joined.md
+++ b/statements/mandatory/joined.md
@@ -20,7 +20,7 @@ A participant has joined the virtual classroom session.
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -53,7 +53,7 @@ A participant has joined the virtual classroom session.
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://activitystrea.ms/join` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/mandatory/left.md
+++ b/statements/mandatory/left.md
@@ -20,7 +20,7 @@ A participant has left the virtual classroom session.
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -51,7 +51,7 @@ A participant has left the virtual classroom session.
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://activitystrea.ms/leave` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/mandatory/terminated.md
+++ b/statements/mandatory/terminated.md
@@ -20,7 +20,7 @@ The virtual classroom session has terminated. The session ends when the last par
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -55,7 +55,7 @@ The virtual classroom session has terminated. The session ends when the last par
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/terminated` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/recommended/answered-poll.md
+++ b/statements/recommended/answered-poll.md
@@ -56,7 +56,7 @@ A participant answered to a poll question.
             {
                "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
                "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar"
+                  "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom"
                }
             }
          ],

--- a/statements/recommended/lowered-hand.md
+++ b/statements/recommended/lowered-hand.md
@@ -20,7 +20,7 @@ A user has lowered the hand in the discussion.
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A user has lowered the hand in the discussion.
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/recommended/muted.md
+++ b/statements/recommended/muted.md
@@ -20,7 +20,7 @@ A participant has been muted. The action has been done by the participant itself
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A participant has been muted. The action has been done by the participant itself
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 
 ## Rules

--- a/statements/recommended/posted-public-message.md
+++ b/statements/recommended/posted-public-message.md
@@ -33,7 +33,7 @@ A participant has posted a public message in the virtual classroom chat.
             {
                "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
                "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar"
+                  "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom"
                }
             }
          ],

--- a/statements/recommended/raised-hand.md
+++ b/statements/recommended/raised-hand.md
@@ -20,7 +20,7 @@ A user has raised the hand to take part in the discussion in the virtual classro
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A user has raised the hand to take part in the discussion in the virtual classro
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/recommended/shared-screen.md
+++ b/statements/recommended/shared-screen.md
@@ -20,7 +20,7 @@ A participant shared the screen on a given virtual classroom session.
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A participant shared the screen on a given virtual classroom session.
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 ## Rules
 

--- a/statements/recommended/started-camera.md
+++ b/statements/recommended/started-camera.md
@@ -20,7 +20,7 @@ A user has started the camera. The action has been done by the participant itsel
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A user has started the camera. The action has been done by the participant itsel
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 
 ## Rules

--- a/statements/recommended/started-poll.md
+++ b/statements/recommended/started-poll.md
@@ -52,7 +52,7 @@ A poll has been started in the virtual classroom in order to collect participant
             {
                "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
                "definition": {
-                  "type": "http://id.tincanapi.com/activitytype/webinar"
+                  "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom"
                }
             }
          ],

--- a/statements/recommended/stopped-camera.md
+++ b/statements/recommended/stopped-camera.md
@@ -20,7 +20,7 @@ A user has stopped the camera. The action has been done by the participant itsel
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A user has stopped the camera. The action has been done by the participant itsel
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 
 ## Rules

--- a/statements/recommended/unmuted.md
+++ b/statements/recommended/unmuted.md
@@ -20,7 +20,7 @@ A user has been unmuted. The action has been done by the participant itself or b
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -52,7 +52,7 @@ A user has been unmuted. The action has been done by the participant itself or b
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 
 ## Rules

--- a/statements/recommended/unshared-screen.md
+++ b/statements/recommended/unshared-screen.md
@@ -20,7 +20,7 @@ A user has unshared the screen.
    "object": {
       "id": "http://gaiax.org/xapi/activities/e59490e1-ddf2-4c43-bfdc-14e274abc106",
       "definition": {
-         "type": "http://id.tincanapi.com/activitytype/webinar",
+         "type": "https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom",
          "name": {
             "en": "xAPI 101"
          }
@@ -53,7 +53,7 @@ A user has unshared the screen.
 | Property  | Value         |
 |----------------|-----------------|
 | verb.id | Must be `http://adlnet.gov/expapi/verbs/interacted` |
-| object.type | Must be `http://id.tincanapi.com/activitytype/webinar` |
+| object.type | Must be `https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom` |
 
 
 ## Rules


### PR DESCRIPTION
# Purpose

The activity type representing the virtual classroom is specific to this
profile. Hence it should not use the webinar activity type from tincan, as a
webinar is more restrictive regarding user interactions and virtual classroom is
specific to education.

# Proposal

Define the following activity type in this profile and replace every use of
webinar with it:

`https://w3id.org/xapi/virtual-classroom/activity-types/virtual-classroom`

