### PR TITLE
Add presence for missing statement rules

### DIFF
--- a/statements/mandatory/initialized.md
+++ b/statements/mandatory/initialized.md
@@ -57,7 +57,7 @@ The virtual classroom session has started. The session is initialized when the f
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.http://id.tincanapi.com/extension/planned-duration`: RECOMMENDED, ISO 8601 duration.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/mandatory/joined.md
+++ b/statements/mandatory/joined.md
@@ -58,7 +58,7 @@ A participant has joined the virtual classroom session.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/camera-activated`: RECOMMENDED, boolean.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/micro-activated`: RECOMMENDED, boolean.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).

--- a/statements/mandatory/left.md
+++ b/statements/mandatory/left.md
@@ -56,7 +56,7 @@ A participant has left the virtual classroom session.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.
 - This statement MUST also be sent for the person who stopped the virtual classroom (statement `terminated`). 

--- a/statements/mandatory/terminated.md
+++ b/statements/mandatory/terminated.md
@@ -61,7 +61,7 @@ The virtual classroom session has terminated. The session ends when the last par
 
 - `result.duration`: INCLUDED, ISO 8601 duration, time between the `initialized` and `terminated` statements.
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.http://id.tincanapi.com/extension/planned-duration`: RECOMMENDED, ISO 8601 duration.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/answered-poll.md
+++ b/statements/recommended/answered-poll.md
@@ -89,7 +89,7 @@ A participant answered to a poll question.
 - `object.definition`: CMI interaction, including a content type set to `http://adlnet.gov/expapi/activities/cmi.interaction` and other related properties as described in the xAPI specification.
 - `result.response`: INCLUDED, must be consistent with the `correctResponsesPattern` format in case of multiple answers (`[,]` is used as a separator).
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.parent`: MUST be the virtual classroom activity.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.parent`: INCLUDED, MUST be the virtual classroom activity.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/lowered-hand.md
+++ b/statements/recommended/lowered-hand.md
@@ -57,7 +57,7 @@ A user has lowered the hand in the discussion.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/hand-raised`: INCLUDED, boolean, must be set to `False`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/muted.md
+++ b/statements/recommended/muted.md
@@ -58,7 +58,7 @@ A participant has been muted. The action has been done by the participant itself
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/micro-activated`: INCLUDED, boolean, must be set to `False`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/posted-public-message.md
+++ b/statements/recommended/posted-public-message.md
@@ -64,8 +64,8 @@ A participant has posted a public message in the virtual classroom chat.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.parent`: MUST be the virtual classroom activity.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.parent`: INCLUDED, MUST be the virtual classroom activity.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.
 

--- a/statements/recommended/raised-hand.md
+++ b/statements/recommended/raised-hand.md
@@ -57,7 +57,7 @@ A user has raised the hand to take part in the discussion in the virtual classro
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/hand-raised`: INCLUDED, boolean, must be set to `True`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/shared-screen.md
+++ b/statements/recommended/shared-screen.md
@@ -57,7 +57,7 @@ A participant shared the screen on a given virtual classroom session.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/screen-shared`: INCLUDED, boolean, must be set to `True`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/started-camera.md
+++ b/statements/recommended/started-camera.md
@@ -58,7 +58,7 @@ A user has started the camera. The action has been done by the participant itsel
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/camera-activated`: INCLUDED, boolean, must be set to `True`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/started-poll.md
+++ b/statements/recommended/started-poll.md
@@ -85,7 +85,7 @@ A poll has been started in the virtual classroom in order to collect participant
 
 - `object.definition`: CMI interaction, including a content type set to `http://adlnet.gov/expapi/activities/cmi.interaction` and other related properties as described in the xAPI specification.
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.parent`: MUST be the virtual classroom activity.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.parent`: INCLUDED, MUST be the virtual classroom activity.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/stopped-camera.md
+++ b/statements/recommended/stopped-camera.md
@@ -58,7 +58,7 @@ A user has stopped the camera. The action has been done by the participant itsel
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/camera-activated`: INCLUDED, boolean, must be set to `False`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/unmuted.md
+++ b/statements/recommended/unmuted.md
@@ -58,7 +58,7 @@ A user has been unmuted. The action has been done by the participant itself or b
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/micro-activated`: INCLUDED, boolean, must be set to `True`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.

--- a/statements/recommended/unshared-screen.md
+++ b/statements/recommended/unshared-screen.md
@@ -59,7 +59,7 @@ A user has unshared the screen.
 ## Rules
 
 - `context.registration`: INCLUDED, must be the same for all the statements of a planned session, even when the virtual classroom is relaunched for technical reasons.
-- `context.contextActivities.category`: MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
+- `context.contextActivities.category`: INCLUDED, MUST contain an activity with the `https://w3id.org/xapi/virtual-classroom` id.
 - `context.extensions.https://w3id.org/xapi/virtual-classroom/extensions/screen-shared`: INCLUDED, boolean, must be set to `False`.
 - `context.extensions.https://w3id.org/xapi/cmi5/context/extensions/sessionid`: INCLUDED, UUID format, must be the same for all the statements from `initialized` to `terminated` (i.e. technical session).
 - `timestamp`: INCLUDED.


### PR DESCRIPTION
## Purpose

Presence rule was missing for `category` and `parent` fields of
`context.contextActivities`.

## Proposal

 It has been set to `INCLUDED`.
